### PR TITLE
Header attribute for configuration was not getting properly initialized to default value

### DIFF
--- a/lib/p3p/configuration.rb
+++ b/lib/p3p/configuration.rb
@@ -4,7 +4,7 @@ module P3P
     attr_accessor :header
 
     def initialize
-      header = DEFAULT_HEADER
+      @header = DEFAULT_HEADER
     end
   end
 end


### PR DESCRIPTION
Ruby treats `foo = ...` as a local variable assignment and does not think to look for a `foo=` method on the current instance (whether defined explicitly or with `attr_accessor`).  In order to force use of the instance method, one can call `self.foo = ...`, or of course in this case we can just assign the instance variable directly (which I prefer for `initialize`).

For me this caused a nil error in the bowels of passenger trying to start up because there was no value for the header.  I can work around for the time being by explicitly setting the configuration in an initializer and avoiding the default header.
